### PR TITLE
Created a unit test that shows exception being thrown when calling 'ToString()' on a DateTime member.

### DIFF
--- a/NoNulls/NoNulls.Tests/SampleData/TestDataTypes.cs
+++ b/NoNulls/NoNulls.Tests/SampleData/TestDataTypes.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace NoNulls.Tests.SampleData
 {    
-    internal sealed class User
+    public sealed class User
     {
         public School School { get; set; }
 
@@ -23,9 +23,11 @@ namespace NoNulls.Tests.SampleData
         public Dictionary<User, User> ClassMatesDict { get; set; }
 
         public HashSet<User> ClassMatesHash { get; set; }
+
+        public DateTime DateOfBirth { get; set; }
     }
 
-    internal sealed class School
+    public sealed class School
     {
         public District District { get; set; }
 
@@ -43,7 +45,7 @@ namespace NoNulls.Tests.SampleData
         }
     }
 
-    internal sealed class District
+    public sealed class District
     {
         public Street Street { get; set; }
 
@@ -53,7 +55,7 @@ namespace NoNulls.Tests.SampleData
         }
     }
 
-    internal class Street
+    public class Street
     {
         public String Name { get; set; }
 

--- a/NoNulls/NoNulls.Tests/Tests/ExpressionTests.cs
+++ b/NoNulls/NoNulls.Tests/Tests/ExpressionTests.cs
@@ -45,7 +45,7 @@ namespace NoNulls.Tests.Tests
     }
 
     [TestClass]
-    internal  class ExpressionTests
+    public  class ExpressionTests
     {
         
         [TestMethod]
@@ -85,6 +85,20 @@ namespace NoNulls.Tests.Tests
             user.Number = 0;
 
             var name = Option.CompileChain<User, int>(u => u.Number)(user);
+
+            Assert.IsTrue(name.ValidChain());
+        }
+
+        [TestMethod]
+        public void TestWithDateTimeValueTypeTargetAndToString()
+        {
+            var user = new User();
+
+            user.Number = 0;
+
+            // This is currently throwing exception - "Reference equality is not defined for the types 'System.DateTime' and 'System.Object'" 
+            // in line 128 of NullVisitor.cs class.
+            var name = Option.CompileChain<User, string>(u => u.DateOfBirth.ToShortDateString())(user);
 
             Assert.IsTrue(name.ValidChain());
         }


### PR DESCRIPTION
Had to change the unit tests from internal to public. My reshaper test runner doesn't seem to see them otherwise. 
