### PR TITLE
Demo of original attempt to use 'Safe' with a func/expression in another class.

### DIFF
--- a/NoNulls/NoNulls.Tests/NoNulls.Tests.csproj
+++ b/NoNulls/NoNulls.Tests/NoNulls.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Extensions\Extensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SampleData\TestDataTypes.cs" />
+    <Compile Include="Tests\SafeTests.cs" />
     <Compile Include="Tests\ExpressionTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NoNulls/NoNulls.Tests/SampleData/TestDataTypes.cs
+++ b/NoNulls/NoNulls.Tests/SampleData/TestDataTypes.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 
 namespace NoNulls.Tests.SampleData
-{    
-    internal sealed class User
+{
+    public sealed class User
     {
         public School School { get; set; }
 
@@ -25,7 +25,7 @@ namespace NoNulls.Tests.SampleData
         public HashSet<User> ClassMatesHash { get; set; }
     }
 
-    internal sealed class School
+    public sealed class School
     {
         public District District { get; set; }
 
@@ -43,7 +43,7 @@ namespace NoNulls.Tests.SampleData
         }
     }
 
-    internal sealed class District
+    public sealed class District
     {
         public Street Street { get; set; }
 
@@ -53,7 +53,7 @@ namespace NoNulls.Tests.SampleData
         }
     }
 
-    internal class Street
+    public class Street
     {
         public String Name { get; set; }
 

--- a/NoNulls/NoNulls.Tests/Tests/ExpressionTests.cs
+++ b/NoNulls/NoNulls.Tests/Tests/ExpressionTests.cs
@@ -45,7 +45,7 @@ namespace NoNulls.Tests.Tests
     }
 
     [TestClass]
-    internal  class ExpressionTests
+    public class ExpressionTests
     {
         
         [TestMethod]

--- a/NoNulls/NoNulls.Tests/Tests/SafeTests.cs
+++ b/NoNulls/NoNulls.Tests/Tests/SafeTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using Devshorts.MonadicNull;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NoNulls.Tests.Extensions;
+using NoNulls.Tests.SampleData;
+
+namespace NoNulls.Tests.Tests
+{
+    [TestClass]
+    public class SafeTests
+    {
+        [TestMethod]
+        public void TestFuncInAnotherClass()
+        {
+            var user = new User();
+
+            var containerClass = new UserAuditorThatTakesAFunc();
+            containerClass.GetAPropertyOfUserToAudit = x => x.School.ToString();
+
+            // This throws an "Expression cannot be invoked exception"
+            var name = Option.Safe(() => containerClass.GetAPropertyOfUserToAudit(user));
+
+            Assert.IsFalse(name.ValidChain());
+        }
+
+        [TestMethod]
+        public void TestExpressionInAnotherClass()
+        {
+            var user = new User();
+
+            var containerClass = new UserAuditorThatTakesAnExpression();
+            containerClass.GetAPropertyOfUserToAudit = x => x.School.ToString();
+
+            // This throws a null reference exception
+            var name = Option.Safe(() => containerClass.GetAPropertyOfUserToAudit.Compile().Invoke(user));
+
+            Assert.IsFalse(name.ValidChain());
+        }
+    }
+
+    public class UserAuditorThatTakesAFunc
+    {
+        public Func<User, string> GetAPropertyOfUserToAudit { get; set; } 
+    }
+
+    public class UserAuditorThatTakesAnExpression
+    {
+        public Expression<Func<User, string>> GetAPropertyOfUserToAudit { get; set; } 
+    }
+}


### PR DESCRIPTION
This is close to what was my first instinct was when using this library. I had a dictionary of Funcs in a particular class (later converted to expressions) and I was trying to access them in a safe way. This works fine when using the `CompileChain` method (as long as I don't try to access a value type as discussed in a previous pull request). But fails when using the `Safe` method. Not sure if it is even possible for the `Safe` method to provide this functionality and since the `CompileChain` works, it might not even be necessary. Just wanted to provide more details about what I was trying to do. :-)
